### PR TITLE
Migrate to discrete id parts for internal struct

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,7 +68,7 @@ linters:
     - maintidx
     - makezero
     - misspell
-    - musttag
+    #- musttag
     - nakedret
     #- nestif
     - nilerr

--- a/extra/file.go
+++ b/extra/file.go
@@ -5,33 +5,43 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
 	"strings"
 
 	"github.com/leighmacdonald/steamid/v3/steamid"
 )
 
 var (
-	ErrIDType    = errors.New("invalid sid type")
+	ErrIDType = errors.New("invalid sid type")
+
 	ErrReadInput = errors.New("error while reading input")
-	ErrWrite     = errors.New("failed to write to output file")
-	ErrFlush     = errors.New("failed to flush contents")
+
+	ErrWrite = errors.New("failed to write to output file")
+
+	ErrFlush = errors.New("failed to flush contents")
 )
 
 // ParseReader attempt to find all types of steam ids in the data stream provided by the
+
 // input reader. It will write the output of what it finds to the output writer applying the
+
 // formatting strings to each value. The formatting string takes the same formatting as the
+
 // standards fmt.SprintF() and expects one %s token.
+
 //
+
 // A formatting example to place each steam id on a newline: "%s\n"
+
 //
+
 // idType specifies what output id format to use when writing: steam, steam3, steam32, steam64 are
+
 // the valid choices.
+
 func ParseReader(input io.Reader, output io.Writer, format string, idType string) error {
 	switch idType {
 	case "steam":
 	case "steam3":
-	case "steam32":
 	case "steam64":
 	default:
 		return fmt.Errorf("%w: %s", ErrIDType, idType)
@@ -41,6 +51,7 @@ func ParseReader(input io.Reader, output io.Writer, format string, idType string
 	reader := bufio.NewScanner(input)
 
 	var lines []string
+
 	for reader.Scan() {
 		lines = append(lines, reader.Text())
 	}
@@ -49,20 +60,16 @@ func ParseReader(input io.Reader, output io.Writer, format string, idType string
 		return errors.Join(err, ErrReadInput)
 	}
 
-	ids64 := steamid.ParseString(strings.Join(lines, ""))
-
-	for _, id := range ids64 {
+	for _, id := range steamid.ParseString(strings.Join(lines, "")) {
 		value := ""
 
 		switch idType {
 		case "steam64":
 			value = id.String()
-		case "steam32":
-			value = strconv.FormatInt(int64(steamid.SID64ToSID32(id)), 10)
 		case "steam3":
-			value = string(steamid.SID64ToSID3(id))
+			value = string(id.Steam3())
 		case "steam":
-			value = string(steamid.SID64ToSID(id))
+			value = string(id.Steam(false))
 		}
 
 		_, errWrite := writer.WriteString(fmt.Sprintf(format, value))

--- a/extra/status.go
+++ b/extra/status.go
@@ -51,7 +51,7 @@ type Status struct {
 type Player struct {
 	UserID        int
 	Name          string
-	SID           steamid.SID64
+	SID           steamid.SteamID
 	ConnectedTime time.Duration
 	Ping          int
 	Loss          int
@@ -64,8 +64,8 @@ type Player struct {
 
 // set of SID64s representing all the players.
 
-func SIDSFromStatus(text string) []steamid.SID64 {
-	var ids []steamid.SID64
+func SIDSFromStatus(text string) []steamid.SteamID {
+	var ids []steamid.SteamID
 
 	found := reStatusID.FindAllString(text, -1)
 
@@ -74,7 +74,7 @@ func SIDSFromStatus(text string) []steamid.SID64 {
 	}
 
 	for _, strID := range found {
-		ids = append(ids, steamid.SID3ToSID64(steamid.SID3(strID)))
+		ids = append(ids, steamid.New(strID))
 	}
 
 	return ids
@@ -184,7 +184,7 @@ func ParseStatus(status string, full bool) (Status, error) {
 				p := Player{
 					UserID:        int(userID),
 					Name:          m[2],
-					SID:           steamid.SID3ToSID64(steamid.SID3(m[3])),
+					SID:           steamid.New(m[3]),
 					ConnectedTime: dur,
 					Ping:          int(ping),
 					Loss:          int(loss),

--- a/extra/status_test.go
+++ b/extra/status_test.go
@@ -11,70 +11,39 @@ func TestParseStatus(t *testing.T) {
 	t.Parallel()
 
 	statusText := `hostname: Uncletopia | US West 2
-
 version : 5970214/24 5970214 secure
-
 udp/ip  : 23.239.22.163:27015  (public ip: 23.239.22.163)
-
 steamid : [G:1:3414356] (85568392923453780)
-
 account : not logged in  (No account specified)
-
 map     : pl_goldrush at: 0 x, 0 y, 0 z
-
 tags    : Uncletopia,nocrits,nodmgspread,payload
-
 players : 11 humans, 0 bots (32 max)
-
 edicts  : 1717 used of 2048 max
-
 # userid name                uniqueid            connected ping loss state  adr
-
 #   4247 "Dulahan"           [U:1:148883280]     55:09       74    0 active 1.2.64.84:27005
-
 #   4235 "Nox"               [U:1:186134686]      1:21:18   123    0 active 1.2.212.98:27005
-
 #   4262 "George Scrumpus"   [U:1:64274886]      17:09      118    0 active 1.2.121.68:27005
-
 #   4254 "airbud"            [U:1:190163035]     38:49       72    0 active 1.2.246.238:27005
-
 #   4256 "Kensei"            [U:1:119851869]     36:33       53    0 active 1.2.110.66:27005
-
 #   4268 "Progseeks"         [U:1:191380023]     01:43      105    0 active 1.2.67.76:27005
-
 #   4181 "Gera"              [U:1:202327912]      2:39:57   104    0 active 1.2.62.100:27005
-
 #   4271 "A Good Idea"       [U:1:431565997]     00:41       68    0 active 1.2.104.247:27005
-
 #   4212 "Chance The Memer"  [U:1:106864873]      1:51:58   106    0 active 1.2.215.62:27005
-
 #   4259 "Greenwood RN"      [U:1:128375332]     24:51       67    0 active 1.2.136.246:27005
-
 #   4246 "Frank"             [U:1:166415783]      1:01:59   133    0 active 1.2.23.197:27005
-
 `
 
 	ids := extra.SIDSFromStatus(statusText)
-
 	require.NotNil(t, ids)
-
 	require.Equal(t, len(ids), 11)
 
 	parsedStatus, err := extra.ParseStatus(statusText, true)
-
 	require.NoError(t, err)
-
 	require.Equal(t, "Uncletopia | US West 2", parsedStatus.ServerName)
-
 	require.Equal(t, 32, parsedStatus.PlayersMax)
-
 	require.Equal(t, 11, parsedStatus.PlayersCount)
-
 	require.Equal(t, "pl_goldrush", parsedStatus.Map)
-
 	require.Equal(t, []int{1717, 2048}, parsedStatus.Edicts)
-
 	require.Equal(t, []string{"Uncletopia", "nocrits", "nodmgspread", "payload"}, parsedStatus.Tags)
-
 	require.Equal(t, "5970214/24 5970214 secure", parsedStatus.Version)
 }


### PR DESCRIPTION
Splits the internal struct format into discreet parts:

- universe
- instance
- accountType 
- accountID

Removes unnecessary functions:
- XtoX conversion funcs
- Separate GID type