### PR TITLE
Add yaml marhsaller/unmarshaller

### DIFF
--- a/steamid/steamid.go
+++ b/steamid/steamid.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -519,6 +521,21 @@ func (t *SteamID) UnmarshalJSON(data []byte) error {
 		return ErrInvalidSID
 	}
 
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler which is used by the yaml package for marshalling
+func (t *SteamID) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for steam ids.
+func (t *SteamID) UnmarshalYAML(node *yaml.Node) error {
+	sid := New(node.Value)
+	if !sid.Valid() {
+		return ErrInvalidSID
+	}
+	*t = sid
 	return nil
 }
 

--- a/steamid/steamid_test.go
+++ b/steamid/steamid_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/leighmacdonald/steamid/v4/steamid"
 	"github.com/stretchr/testify/require"
 )
@@ -120,6 +122,34 @@ func TestJSON(t *testing.T) {
 
 	var r testGIDResp
 	require.NoError(t, json.Unmarshal([]byte(`{"gid":"103582791441572968"}`), &r))
+	expectedGID := steamid.New(103582791441572968)
+
+	require.Equal(t, expectedGID.Int64(), r.GID.Int64())
+}
+
+func TestYAML(t *testing.T) {
+	t.Parallel()
+
+	type testFormats struct {
+		Quoted steamid.SteamID `yaml:"quoted"`
+	}
+
+	var out testFormats
+	require.NoError(t, yaml.Unmarshal([]byte(`{"quoted":"76561197970669109"}`), &out))
+
+	expected := steamid.New(76561197970669109)
+	require.Equal(t, expected, out.Quoted, "Quoted value invalid")
+
+	body, errMarshal := yaml.Marshal(&expected)
+	require.NoError(t, errMarshal)
+	require.Equal(t, []byte("\"76561197970669109\"\n"), body)
+
+	type testGIDResp struct {
+		GID steamid.SteamID `json:"gid"`
+	}
+
+	var r testGIDResp
+	require.NoError(t, yaml.Unmarshal([]byte(`{"gid":"103582791441572968"}`), &r))
 	expectedGID := steamid.New(103582791441572968)
 
 	require.Equal(t, expectedGID.Int64(), r.GID.Int64())


### PR DESCRIPTION
Implements encoding.TextMarshaler and yaml.Unmarshaler interfaces to marshal/unmarshal to/from yaml .